### PR TITLE
fix: remove rogue slash poisoning download path

### DIFF
--- a/runblender.ipynb
+++ b/runblender.ipynb
@@ -68,7 +68,7 @@
         "elif blender_version == \"blender2.90.1\":\n",
         "    download_path=\"https://ftp.halifax.rwth-aachen.de/blender/release/Blender2.90/blender-2.90.1-linux64.tar.xz\"\n",
         "elif blender_version == \"blender2.91.2\":\n",
-        "    download_path=\"https://ftp.halifax.rwth-aachen.de/blender/release/Blender2.91/blender-2.91.2-linux64.tar.xz/\""
+        "    download_path=\"https://ftp.halifax.rwth-aachen.de/blender/release/Blender2.91/blender-2.91.2-linux64.tar.xz\""
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
A trailing slash caused a 404 response by the download server.

Should fix #22